### PR TITLE
Remove message and presence handlers when leaving a room

### DIFF
--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -5,11 +5,13 @@ Plugin to implement the MUC extension. http://xmpp.org/extensions/xep-0045.html
 /* global document, window, setTimeout, clearTimeout, console,
     XMLHttpRequest, ActiveXObject,
     Base64, MD5,
-    Strophe, $build, $msg, $iq, $pres 
+    Strophe, $build, $msg, $iq, $pres
 */
 
 Strophe.addConnectionPlugin('muc', {
     _connection: null,
+    _roomMessageHandlers: [],
+    _roomPresenceHandlers: [],
     // The plugin must have the init function
     /***Function
     Initialize the MUC plugin. Sets the correct connection object and
@@ -17,9 +19,9 @@ Strophe.addConnectionPlugin('muc', {
     */
     init: function(conn) {
         this._connection = conn;
-        /* extend name space 
+        /* extend name space
          *  NS.MUC - XMPP Multi-user chat namespace
-         *              from XEP 45.  
+         *              from XEP 45.
          *
          */
         Strophe.addNamespace('MUC_OWNER', Strophe.NS.MUC+"#owner");
@@ -38,20 +40,20 @@ Strophe.addConnectionPlugin('muc', {
     rooms only)
     */
     join: function(room, nick, msg_handler_cb, pres_handler_cb, password) {
-        var room_nick = this.test_append_nick(room, nick);        
+        var room_nick = this.test_append_nick(room, nick);
         var msg = $pres({from: this._connection.jid,
                          to: room_nick})
             .c("x",{xmlns: Strophe.NS.MUC});
         if (password)
         {
-            var password_elem = Strophe.xmlElement("password", 
+            var password_elem = Strophe.xmlElement("password",
                                                    [],
                                                    password);
             msg.cnode(password_elem);
         }
         if (msg_handler_cb)
         {
-            this._connection.addHandler(function(stanza) {
+            this._roomMessageHandlers[room] = this._connection.addHandler(function(stanza) {
                 var from = stanza.getAttribute('from');
                 var roomname = from.split("/");
                 // filter on room name
@@ -72,7 +74,7 @@ Strophe.addConnectionPlugin('muc', {
         }
         if (pres_handler_cb)
         {
-            this._connection.addHandler(function(stanza) {
+            this._roomPresenceHandlers[room] = this._connection.addHandler(function(stanza) {
                 var xquery = stanza.getElementsByTagName("x");
                 if (xquery.length > 0)
                 {
@@ -80,14 +82,14 @@ Strophe.addConnectionPlugin('muc', {
                     for (var i = 0; i < xquery.length; i++)
                     {
                         var xmlns = xquery[i].getAttribute("xmlns");
-                        
+
                         if (xmlns && xmlns.match(Strophe.NS.MUC))
                         {
                             return pres_handler_cb(stanza);
                         }
                     }
                 }
-                return true;                
+                return true;
             },
                                         null,
                                         "presence",
@@ -107,7 +109,9 @@ Strophe.addConnectionPlugin('muc', {
     iqid - The unique id for the room leave.
     */
     leave: function(room, nick, handler_cb) {
-        var room_nick = this.test_append_nick(room, nick);        
+        this._connection.deleteHandler(this._roomMessageHandlers[room]);
+        this._connection.deleteHandler(this._roomPresenceHandlers[room]);
+        var room_nick = this.test_append_nick(room, nick);
         var presenceid = this._connection.getUniqueId();
         var presence = $pres({type: "unavailable",
                               id: presenceid,
@@ -132,7 +136,7 @@ Strophe.addConnectionPlugin('muc', {
     msgiq - the unique id used to send the message
     */
     message: function(room, nick, message) {
-        var room_nick = this.test_append_nick(room, nick);        
+        var room_nick = this.test_append_nick(room, nick);
         var msgid = this._connection.getUniqueId();
         var msg = $msg({to: room_nick,
                         from: this._connection.jid,
@@ -197,7 +201,7 @@ Strophe.addConnectionPlugin('muc', {
         var stanza = config.tree();
         return this._connection.sendIQ(stanza,
                                        function(){},
-                                       function(){});        
+                                       function(){});
     },
     /***Function
     Parameters:
@@ -286,14 +290,14 @@ Strophe.addConnectionPlugin('muc', {
         var iq = $iq({to: server,
                       from: this._connection.jid,
                       type: "get"})
-            .c("query",{xmlns: Strophe.NS.DISCO_ITEMS});        
-        this._connection.sendIQ(iq, handle_cb, function(){});        
+            .c("query",{xmlns: Strophe.NS.DISCO_ITEMS});
+        this._connection.sendIQ(iq, handle_cb, function(){});
     },
     test_append_nick: function(room, nick) {
         var room_nick = room;
-        if (nick) 
+        if (nick)
         {
-            room_nick += "/" + Strophe.escapeNode(nick); 
+            room_nick += "/" + Strophe.escapeNode(nick);
         }
         return room_nick;
     }


### PR DESCRIPTION
In strope.muc.js: Remove message and presence handlers when leaving a room (see reported issue https://github.com/metajack/strophejs-plugins/issues#issue/5). Delete white spaces at end of lines. 
