### PR TITLE
MUC Message Callback should handle server provided messages

### DIFF
--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -55,7 +55,7 @@ Strophe.addConnectionPlugin('muc', {
                 var from = stanza.getAttribute('from');
                 var roomname = from.split("/");
                 // filter on room name
-                if (roomname.length > 1 && roomname[0] == room)
+                if (roomname[0] == room)
                 {
                     return msg_handler_cb(stanza);
                 }


### PR DESCRIPTION
My server (Ejabberd) always provides the subject when the user joins the room. This code was filtering that because the 'from' is the room, not a user specifically.

From the server:
`<message xmlns="jabber:client" type="groupchat" from="1@conference.example.com" to="loe6@example.com/2962146351295568910515397"><subject>arggg</subject><body>Andrew has set the subject to: arggg</body></message>`

I see no reason why that can't work when this is acceptable:

`<message xmlns="jabber:client" type="groupchat" to="loe6@example.com/2962146351295568910515397" from="1@conference.example.com/Adium"><subject>this is the new topic</subject></message>`
