### PR TITLE
Allow to send private (user-to-user) messages via the muc plugin. 

### DIFF
--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -131,12 +131,13 @@ Strophe.addConnectionPlugin('muc', {
     Returns:
     msgiq - the unique id used to send the message
     */
-    message: function(room, nick, message) {
+    message: function(room, nick, message, type) {
         var room_nick = this.test_append_nick(room, nick);        
+        type = type ? "groupchat";
         var msgid = this._connection.getUniqueId();
         var msg = $msg({to: room_nick,
                         from: this._connection.jid,
-                        type: "groupchat",
+                        type: type,
                         id: msgid}).c("body",
                                       {xmlns: Strophe.NS.CLIENT}).t(message);
         msg.up().c("x", {xmlns: "jabber:x:event"}).c("composing");

--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -133,7 +133,7 @@ Strophe.addConnectionPlugin('muc', {
     */
     message: function(room, nick, message, type) {
         var room_nick = this.test_append_nick(room, nick);        
-        type = type ? "groupchat";
+        type = type || "groupchat";
         var msgid = this._connection.getUniqueId();
         var msg = $msg({to: room_nick,
                         from: this._connection.jid,

--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -128,6 +128,7 @@ Strophe.addConnectionPlugin('muc', {
     (String) room - The multi-user chat room name.
     (String) nick - The nick name used in the chat room.
     (String) message - The message to send to the room.
+    (String) type - "groupchat" for group chat messages or "chat" for private chat messages
     Returns:
     msgiq - the unique id used to send the message
     */


### PR DESCRIPTION
The type "chat" is for sending user-to-user messages (with jids in form of room@servicename.example.com/user). I think the muc plugin should support that.
