### PR TITLE
Make handler_cb optional; previously, it was marked optional in the docum

### DIFF
--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -114,12 +114,16 @@ Strophe.addConnectionPlugin('muc', {
                               from: this._connection.jid,
                               to: room_nick})
             .c("x",{xmlns: Strophe.NS.MUC});
-        this._connection.addHandler(handler_cb,
-                                    null,
-                                    "presence",
-                                    null,
-                                    presenceid,
-                                    null);
+        
+        if(handler_cb){
+            this._connection.addHandler(handler_cb,
+                                        null,
+                                        "presence",
+                                        null,
+                                        presenceid,
+                                        null);            
+        }
+
         this._connection.send(presence);
         return presenceid;
     },


### PR DESCRIPTION
Make handler_cb optional; previously, it was marked optional in the documentation, but was actually always added as a handler.
