### PR TITLE
'prependArg' function method is deprecated.

### DIFF
--- a/roster/strophe.roster.js
+++ b/roster/strophe.roster.js
@@ -89,8 +89,8 @@ Strophe.addConnectionPlugin('roster',
         }
         var iq = $iq({type: 'get',  'id' : this._connection.getUniqueId('roster')}).c('query', attrs);
         this._connection.sendIQ(iq,
-                                this._onReceiveRosterSuccess.bind(this).prependArg(userCallback),
-                                this._onReceiveRosterError.bind(this).prependArg(userCallback));
+                                this._onReceiveRosterSuccess.bind(this, userCallback),
+                                this._onReceiveRosterError.bind(this, userCallback));
     },
     /** Function: registerCallback
      * register callback on roster (presence and iq)


### PR DESCRIPTION
'prependArg' function method is deprecated, new bind takes over it's functionality.

Reference: Jack Moffit: Function.prototype.bind and Function.prototype.prependArg (http://groups.google.com/group/strophe/browse_thread/thread/4e41294102b7ecf3)
