### PR TITLE
renamed chat to groupchat as "chat" -> private

### DIFF
--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -174,7 +174,7 @@ Strophe.addConnectionPlugin('muc', {
     Returns:
     msgiq - the unique id used to send the message
     */
-    chat: function(room, message, html_message) {
+    groupchat: function(room, message, html_message) {
         return this.message(room, null, message, html_message);
     },
     /***Function


### PR DESCRIPTION
I just realized, that chat is probably a bad name for sending a groupchat message, because chat means private message in mucs...
