### PR TITLE
class for room and config, more functions

### DIFF
--- a/muc/strophe.muc.coffee
+++ b/muc/strophe.muc.coffee
@@ -508,6 +508,9 @@ class XmppRoom
   saveConfiguration: (configarray) ->
     @client.saveConfiguration @name, configarray
 
+  queryOccupants: (success_cb, error_cb) ->
+    @client.queryOccupants @name, success_cb, error_cb
+
   setTopic: (topic) ->
     @client.setTopic @name, topic
 

--- a/muc/strophe.muc.coffee
+++ b/muc/strophe.muc.coffee
@@ -514,8 +514,7 @@ class XmppRoom
   modifyUser: (nick, role, affiliation, reason) ->
     @client.modifyUser @name, nick, affiliation, reason
 
-  changeNick: (nick) ->
-    @nick = nick
+  changeNick: (@nick) ->
     @client.changeNick @name, nick
 
   setStatus: (show, status) ->
@@ -541,6 +540,8 @@ class RoomConfig
         when "feature"
           @features.push attrs.var.textContent
         when "x"
+          attrs = child.children[0].attributes
+          break if ((not attrs.var.textContent is 'FORM_TYPE') or (not attrs.type.textContent is 'hidden'))
           for field in child.children when not field.attributes.type
             attrs = field.attributes
             # @x[attrs.var.textContent.split("#")[1]] =

--- a/muc/strophe.muc.coffee
+++ b/muc/strophe.muc.coffee
@@ -514,8 +514,41 @@ class XmppRoom
   setTopic: (topic) ->
     @client.setTopic @name, topic
 
-  modifyUser: (nick, role, affiliation, reason) ->
-    @client.modifyUser @name, nick, affiliation, reason
+  modifyRole: (nick, role, reason, success_cb, error_cb) ->
+    @client.modifyRole @room, nick, role, reason, success_cb, error_cb
+
+  kick: (nick, reason, handler_cb, error_cb) ->
+    @client.kick @name, nick, 'none', reason, handler_cb, error_cb
+
+  voice: (nick, reason, handler_cb, error_cb) ->
+    @client.voice @name, nick, 'participant', reason, handler_cb, error_cb
+
+  mute: (nick, reason, handler_cb, error_cb) ->
+    @client.mute @name, nick, 'visitor', reason, handler_cb, error_cb
+
+  op: (nick, reason, handler_cb, error_cb) ->
+    @client.op @name, nick, 'moderator', reason, handler_cb, error_cb
+
+  deop: (nick, reason, handler_cb, error_cb) ->
+    @client.deop @name, nick, 'participant', reason, handler_cb, error_cb
+
+  modifyAffiliation: (jid, affiliation, reason, success_cb, error_cb) ->
+    @client.modifyAffiliation @room, jid, affiliation, reason, success_cb, error_cb
+
+  ban: (jid, reason, handler_cb, error_cb) ->
+    @client.ban @name, jid, 'outcast', reason, handler_cb, error_cb
+
+  member: (jid, reason, handler_cb, error_cb) ->
+    @client.member @name, jid, 'member', reason, handler_cb, error_cb
+
+  revoke: (jid, reason, handler_cb, error_cb) ->
+    @client.revoke @name, jid, 'none', reason, handler_cb, error_cb
+
+  owner: (jid, reason, handler_cb, error_cb) ->
+    @client.owner @name, jid, 'owner', reason, handler_cb, error_cb
+
+  admin: (jid, reason, handler_cb, error_cb) ->
+    @client.admin @name, jid, 'admin', reason, handler_cb, error_cb
 
   changeNick: (@nick) ->
     @client.changeNick @name, nick

--- a/muc/strophe.muc.coffee
+++ b/muc/strophe.muc.coffee
@@ -366,6 +366,20 @@ Strophe.addConnectionPlugin 'muc'
 
     @_modifyPrivilege room, item, reason, handler_cb, error_cb
 
+  kick: (room, nick, reason, handler_cb, error_cb) ->
+    @modifyRole room, nick, 'none', reason, handler_cb, error_cb
+
+  voice: (room, nick, reason, handler_cb, error_cb) ->
+    @modifyRole room, nick, 'participant', reason, handler_cb, error_cb
+
+  mute: (room, nick, reason, handler_cb, error_cb) ->
+    @modifyRole room, nick, 'visitor', reason, handler_cb, error_cb
+
+  op: (room, nick, reason, handler_cb, error_cb) ->
+    @modifyRole room, nick, 'moderator', reason, handler_cb, error_cb
+
+  deop: (room, nick, reason, handler_cb, error_cb) ->
+    @modifyRole room, nick, 'participant', reason, handler_cb, error_cb
 
   ###Function
   Changes the affiliation of a member of a MUC room.
@@ -387,6 +401,21 @@ Strophe.addConnectionPlugin 'muc'
       affiliation: affiliation )
 
     @_modifyPrivilege room, item, reason, handler_cb, error_cb
+
+  ban: (room, jid, reason, handler_cb, error_cb) ->
+    @modifyAffiliation room, jid, 'outcast', reason, handler_cb, error_cb
+
+  member: (room, jid, reason, handler_cb, error_cb) ->
+    @modifyAffiliation room, jid, 'member', reason, handler_cb, error_cb
+
+  revoke: (room, jid, reason, handler_cb, error_cb) ->
+    @modifyAffiliation room, jid, 'none', reason, handler_cb, error_cb
+
+  owner: (room, jid, reason, handler_cb, error_cb) ->
+    @modifyAffiliation room, jid, 'owner', reason, handler_cb, error_cb
+
+  admin: (room, jid, reason, handler_cb, error_cb) ->
+    @modifyAffiliation room, jid, 'admin', reason, handler_cb, error_cb
 
   ###Function
   Change the current users nick name.

--- a/muc/strophe.muc.coffee
+++ b/muc/strophe.muc.coffee
@@ -12,6 +12,7 @@ Strophe.addConnectionPlugin 'muc'
   _connection: null
   _roomMessageHandlers: []
   _roomPresenceHandlers: []
+  rooms: []
   # The plugin must have the init function
   ###Function
   Initialize the MUC plugin. Sets the correct connection object and
@@ -74,6 +75,14 @@ Strophe.addConnectionPlugin 'muc'
           return true
         null
         "presence" )
+
+    @rooms[room] ?= new XmppRoom(
+      @
+      room
+      nick
+      @_roomMessageHandlers[room]
+      @_roomPresenceHandlers[room]
+      password )
 
     @_connection.send msg
 
@@ -464,3 +473,50 @@ Strophe.addConnectionPlugin 'muc'
 
   test_append_nick: (room, nick) ->
     room + if nick? then "/#{Strophe.escapeNode nick}" else ""
+
+class XmppRoom
+  constructor: (@client, @name, @nick, @msg_handler_id, @pres_handler_id, @password) ->
+    @name = Strophe.getBareJidFromJid name
+    @client.rooms[@name] = @
+    @roster = new Array()
+
+  join: (msg_handler_cb, pres_handler_cb) ->
+    @client.join(@name, @nick, null, null, password) if @client.rooms[@name]?
+
+  leave: (handler_cb, message) ->
+    @client.leave @name, @nick, handler_cb, message
+    @client.rooms[@name] = null
+
+  message: (nick, message, html_message, type) ->
+    @client.message @name, nick, message, html_message, type
+
+  groupchat: (message, html_message) ->
+    @client.groupchat @name, message, html_message
+
+  invite: (receiver, reason) ->
+    @client.invite @name, receiver, reason
+
+  directInvite: (receiver, reason) ->
+    @client.directInvite @name, receiver, reason, @password
+
+  configure: (handler_cb) ->
+    @client.configure @name, handler_cb
+
+  cancelConfigure: ->
+    @client.cancelConfigure @name
+
+  saveConfiguration: (configarray) ->
+    @client.saveConfiguration @name, configarray
+
+  setTopic: (topic) ->
+    @client.setTopic @name, topic
+
+  modifyUser: (nick, role, affiliation, reason) ->
+    @client.modifyUser @name, nick, affiliation, reason
+
+  changeNick: (nick) ->
+    @nick = nick
+    @client.changeNick @name, nick
+
+  setStatus: (show, status) ->
+    @client.setStatus @name, @nick, show, status

--- a/muc/strophe.muc.coffee
+++ b/muc/strophe.muc.coffee
@@ -520,3 +520,34 @@ class XmppRoom
 
   setStatus: (show, status) ->
     @client.setStatus @name, @nick, show, status
+
+class RoomConfig
+
+  constructor: (info) ->
+    @parse info if info?
+
+  parse: (result) =>
+    query = result.getElementsByTagName("query")[0].children
+    @identities =  []
+    @features =  []
+    @x = []
+    for child in query
+      attrs = child.attributes
+      switch child.nodeName
+        when "identity"
+          identity = {}
+          identity[attr.name] = attr.textContent for attr in attrs
+          @identities.push identity
+        when "feature"
+          @features.push attrs.var.textContent
+        when "x"
+          for field in child.children when not field.attributes.type
+            attrs = field.attributes
+            # @x[attrs.var.textContent.split("#")[1]] =
+            @x.push (
+              var: attrs.var.textContent
+              label: attrs.label.textContent or ""
+              value: field.firstChild.textContent or "" )
+
+    "identities": @identities, "features": @features, "x": @x
+

--- a/muc/strophe.muc.coffee
+++ b/muc/strophe.muc.coffee
@@ -515,7 +515,7 @@ class XmppRoom
     @client.setTopic @name, topic
 
   modifyRole: (nick, role, reason, success_cb, error_cb) ->
-    @client.modifyRole @room, nick, role, reason, success_cb, error_cb
+    @client.modifyRole @name, nick, role, reason, success_cb, error_cb
 
   kick: (nick, reason, handler_cb, error_cb) ->
     @client.kick @name, nick, 'none', reason, handler_cb, error_cb
@@ -533,7 +533,7 @@ class XmppRoom
     @client.deop @name, nick, 'participant', reason, handler_cb, error_cb
 
   modifyAffiliation: (jid, affiliation, reason, success_cb, error_cb) ->
-    @client.modifyAffiliation @room, jid, affiliation, reason, success_cb, error_cb
+    @client.modifyAffiliation @name, jid, affiliation, reason, success_cb, error_cb
 
   ban: (jid, reason, handler_cb, error_cb) ->
     @client.ban @name, jid, 'outcast', reason, handler_cb, error_cb

--- a/muc/strophe.muc.coffee
+++ b/muc/strophe.muc.coffee
@@ -210,6 +210,23 @@ Strophe.addConnectionPlugin 'muc'
     return msgid
 
   ###Function
+  Queries a room for a list of occupants
+  (String) room - The multi-user chat room name.
+  (Function) success_cb - Optional function to handle the info.
+  (Function) error_cb - Optional function to handle an error.
+  Returns:
+  id - the unique id used to send the info request
+  ###
+  queryOccupants: (room, success_cb, error_cb) ->
+    attrs = {xmlns: Strophe.NS.DISCO_ITEMS};
+    info = $iq(
+      from:this._connection.jid
+      to:room
+      type:'get' )
+    .c('query', attrs)
+    @_connection.sendIQ info, success_cb, error_cb
+
+  ###Function
   Start a room configuration.
   Parameters:
   (String) room - The multi-user chat room name.

--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -568,7 +568,7 @@ XmppRoom = (function() {
   };
 
   XmppRoom.prototype.modifyRole = function(nick, role, reason, success_cb, error_cb) {
-    return this.client.modifyRole(this.room, nick, role, reason, success_cb, error_cb);
+    return this.client.modifyRole(this.name, nick, role, reason, success_cb, error_cb);
   };
 
   XmppRoom.prototype.kick = function(nick, reason, handler_cb, error_cb) {
@@ -592,7 +592,7 @@ XmppRoom = (function() {
   };
 
   XmppRoom.prototype.modifyAffiliation = function(jid, affiliation, reason, success_cb, error_cb) {
-    return this.client.modifyAffiliation(this.room, jid, affiliation, reason, success_cb, error_cb);
+    return this.client.modifyAffiliation(this.name, jid, affiliation, reason, success_cb, error_cb);
   };
 
   XmppRoom.prototype.ban = function(jid, reason, handler_cb, error_cb) {

--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -7,7 +7,8 @@
    Base64, MD5,
    Strophe, $build, $msg, $iq, $pres
 */
-var XmppRoom;
+var RoomConfig, XmppRoom,
+  __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
 Strophe.addConnectionPlugin('muc', {
   _connection: null,
@@ -576,5 +577,57 @@ XmppRoom = (function() {
   };
 
   return XmppRoom;
+
+})();
+
+RoomConfig = (function() {
+
+  function RoomConfig(info) {
+    this.parse = __bind(this.parse, this);    if (info != null) this.parse(info);
+  }
+
+  RoomConfig.prototype.parse = function(result) {
+    var attr, attrs, child, field, identity, query, _i, _j, _k, _len, _len2, _len3, _ref;
+    query = result.getElementsByTagName("query")[0].children;
+    this.identities = [];
+    this.features = [];
+    this.x = [];
+    for (_i = 0, _len = query.length; _i < _len; _i++) {
+      child = query[_i];
+      attrs = child.attributes;
+      switch (child.nodeName) {
+        case "identity":
+          identity = {};
+          for (_j = 0, _len2 = attrs.length; _j < _len2; _j++) {
+            attr = attrs[_j];
+            identity[attr.name] = attr.textContent;
+          }
+          this.identities.push(identity);
+          break;
+        case "feature":
+          this.features.push(attrs["var"].textContent);
+          break;
+        case "x":
+          _ref = child.children;
+          for (_k = 0, _len3 = _ref.length; _k < _len3; _k++) {
+            field = _ref[_k];
+            if (!(!field.attributes.type)) continue;
+            attrs = field.attributes;
+            this.x.push({
+              "var": attrs["var"].textContent,
+              label: attrs.label.textContent || "",
+              value: field.firstChild.textContent || ""
+            });
+          }
+      }
+    }
+    return {
+      "identities": this.identities,
+      "features": this.features,
+      "x": this.x
+    };
+  };
+
+  return RoomConfig;
 
 })();

--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -608,6 +608,10 @@ RoomConfig = (function() {
           this.features.push(attrs["var"].textContent);
           break;
         case "x":
+          attrs = child.children[0].attributes;
+          if ((!attrs["var"].textContent === 'FORM_TYPE') || (!attrs.type.textContent === 'hidden')) {
+            break;
+          }
           _ref = child.children;
           for (_k = 0, _len3 = _ref.length; _k < _len3; _k++) {
             field = _ref[_k];

--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -559,6 +559,10 @@ XmppRoom = (function() {
     return this.client.saveConfiguration(this.name, configarray);
   };
 
+  XmppRoom.prototype.queryOccupants = function(success_cb, error_cb) {
+    return this.client.queryOccupants(this.name, success_cb, error_cb);
+  };
+
   XmppRoom.prototype.setTopic = function(topic) {
     return this.client.setTopic(this.name, topic);
   };

--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -389,6 +389,21 @@ Strophe.addConnectionPlugin('muc', {
     });
     return this._modifyPrivilege(room, item, reason, handler_cb, error_cb);
   },
+  kick: function(room, nick, reason, handler_cb, error_cb) {
+    return this.modifyRole(room, nick, 'none', reason, handler_cb, error_cb);
+  },
+  voice: function(room, nick, reason, handler_cb, error_cb) {
+    return this.modifyRole(room, nick, 'participant', reason, handler_cb, error_cb);
+  },
+  mute: function(room, nick, reason, handler_cb, error_cb) {
+    return this.modifyRole(room, nick, 'visitor', reason, handler_cb, error_cb);
+  },
+  op: function(room, nick, reason, handler_cb, error_cb) {
+    return this.modifyRole(room, nick, 'moderator', reason, handler_cb, error_cb);
+  },
+  deop: function(room, nick, reason, handler_cb, error_cb) {
+    return this.modifyRole(room, nick, 'participant', reason, handler_cb, error_cb);
+  },
   /*Function
   Changes the affiliation of a member of a MUC room.
   The modification can only be done by a room moderator. An error will be
@@ -410,6 +425,21 @@ Strophe.addConnectionPlugin('muc', {
       affiliation: affiliation
     });
     return this._modifyPrivilege(room, item, reason, handler_cb, error_cb);
+  },
+  ban: function(room, jid, reason, handler_cb, error_cb) {
+    return this.modifyAffiliation(room, jid, 'outcast', reason, handler_cb, error_cb);
+  },
+  member: function(room, jid, reason, handler_cb, error_cb) {
+    return this.modifyAffiliation(room, jid, 'member', reason, handler_cb, error_cb);
+  },
+  revoke: function(room, jid, reason, handler_cb, error_cb) {
+    return this.modifyAffiliation(room, jid, 'none', reason, handler_cb, error_cb);
+  },
+  owner: function(room, jid, reason, handler_cb, error_cb) {
+    return this.modifyAffiliation(room, jid, 'owner', reason, handler_cb, error_cb);
+  },
+  admin: function(room, jid, reason, handler_cb, error_cb) {
+    return this.modifyAffiliation(room, jid, 'admin', reason, handler_cb, error_cb);
   },
   /*Function
   Change the current users nick name.

--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -567,8 +567,52 @@ XmppRoom = (function() {
     return this.client.setTopic(this.name, topic);
   };
 
-  XmppRoom.prototype.modifyUser = function(nick, role, affiliation, reason) {
-    return this.client.modifyUser(this.name, nick, affiliation, reason);
+  XmppRoom.prototype.modifyRole = function(nick, role, reason, success_cb, error_cb) {
+    return this.client.modifyRole(this.room, nick, role, reason, success_cb, error_cb);
+  };
+
+  XmppRoom.prototype.kick = function(nick, reason, handler_cb, error_cb) {
+    return this.client.kick(this.name, nick, 'none', reason, handler_cb, error_cb);
+  };
+
+  XmppRoom.prototype.voice = function(nick, reason, handler_cb, error_cb) {
+    return this.client.voice(this.name, nick, 'participant', reason, handler_cb, error_cb);
+  };
+
+  XmppRoom.prototype.mute = function(nick, reason, handler_cb, error_cb) {
+    return this.client.mute(this.name, nick, 'visitor', reason, handler_cb, error_cb);
+  };
+
+  XmppRoom.prototype.op = function(nick, reason, handler_cb, error_cb) {
+    return this.client.op(this.name, nick, 'moderator', reason, handler_cb, error_cb);
+  };
+
+  XmppRoom.prototype.deop = function(nick, reason, handler_cb, error_cb) {
+    return this.client.deop(this.name, nick, 'participant', reason, handler_cb, error_cb);
+  };
+
+  XmppRoom.prototype.modifyAffiliation = function(jid, affiliation, reason, success_cb, error_cb) {
+    return this.client.modifyAffiliation(this.room, jid, affiliation, reason, success_cb, error_cb);
+  };
+
+  XmppRoom.prototype.ban = function(jid, reason, handler_cb, error_cb) {
+    return this.client.ban(this.name, jid, 'outcast', reason, handler_cb, error_cb);
+  };
+
+  XmppRoom.prototype.member = function(jid, reason, handler_cb, error_cb) {
+    return this.client.member(this.name, jid, 'member', reason, handler_cb, error_cb);
+  };
+
+  XmppRoom.prototype.revoke = function(jid, reason, handler_cb, error_cb) {
+    return this.client.revoke(this.name, jid, 'none', reason, handler_cb, error_cb);
+  };
+
+  XmppRoom.prototype.owner = function(jid, reason, handler_cb, error_cb) {
+    return this.client.owner(this.name, jid, 'owner', reason, handler_cb, error_cb);
+  };
+
+  XmppRoom.prototype.admin = function(jid, reason, handler_cb, error_cb) {
+    return this.client.admin(this.name, jid, 'admin', reason, handler_cb, error_cb);
   };
 
   XmppRoom.prototype.changeNick = function(nick) {

--- a/muc/strophe.muc.js
+++ b/muc/strophe.muc.js
@@ -213,6 +213,26 @@ Strophe.addConnectionPlugin('muc', {
     return msgid;
   },
   /*Function
+  Queries a room for a list of occupants
+  (String) room - The multi-user chat room name.
+  (Function) success_cb - Optional function to handle the info.
+  (Function) error_cb - Optional function to handle an error.
+  Returns:
+  id - the unique id used to send the info request
+  */
+  queryOccupants: function(room, success_cb, error_cb) {
+    var attrs, info;
+    attrs = {
+      xmlns: Strophe.NS.DISCO_ITEMS
+    };
+    info = $iq({
+      from: this._connection.jid,
+      to: room,
+      type: 'get'
+    }).c('query', attrs);
+    return this._connection.sendIQ(info, success_cb, error_cb);
+  },
+  /*Function
   Start a room configuration.
   Parameters:
   (String) room - The multi-user chat room name.


### PR DESCRIPTION
I made a mess with my git history, so here are all my changes for the MUC-plugin up until now...

I added:

A class XmppRoom that stores some data specific to a room and can call convenience functions.
A class that stores information about a room (basically what gets returned by a disco-query to a room)
A function queryOccupants that queries a room for a list of occupants

I replaced the modifyUser function by a modifyRole and modifyAffiliation function. modifyUser was broken because it took a nickname, role and affiliation, but all queries that change roles or affiliations ONLY take either a nick and a role or a jid and an affiliation.

I added shortcut function for most authoritative tasks for easy access. (kick, ban, etc.)

The XmppRooms also have shortcuts for all new functions.
