### PR TITLE
a misplacement of a parenthesis was causing a serious bug (dataforms)

### DIFF
--- a/dataforms/src/strophe.x.js
+++ b/dataforms/src/strophe.x.js
@@ -536,7 +536,7 @@ Field = (function() {
             type = "text-private";
             break;
           case "text":
-            r = el.attr("readonly" === "readonly");
+            r = el.attr("readonly") === "readonly";
             if (r) {
               type = "fixed";
             } else {


### PR DESCRIPTION
a misplacement of a parenthesis was causing a serious bug (dataforms)
