### PR TITLE
Get JID and Service info when Strophe attaches a session

### DIFF
--- a/pubsub/strophe.pubsub.js
+++ b/pubsub/strophe.pubsub.js
@@ -149,7 +149,8 @@ Extend connection object to have plugin name 'pubsub'.
     // Called by Strophe on connection event
     statusChanged: function (status, condition) {
         var that = this._connection;
-        if (this._autoService && status === Strophe.Status.CONNECTED) {
+        if (this._autoService && 
+		(status === Strophe.Status.CONNECTED || status === Strophe.Status.ATTACHED)) {
             this.service =  'pubsub.'+Strophe.getDomainFromJid(that.jid);
             this.jid = that.jid;
         }


### PR DESCRIPTION
The function onStatus of the pubsub plugin sets the JID and Service vars needed for executing actions when Strophe sends an status of CONNECTED.

If the user is reattaching / attaching to an existing session, those variables are not initialized.

This commit makes it possible to update those variables when Strophe reports the status ATTACHED.
