### PR TITLE
IE10 supports both CORS and XDomainRequest; allow IE10 to use native CORS support

### DIFF
--- a/iexdomain/iexdomain.js
+++ b/iexdomain/iexdomain.js
@@ -1,7 +1,8 @@
 Strophe.addConnectionPlugin('iexdomain', {
     init: function(conn) {
         // replace Strophe.Request._newXHR with new IE CrossDomain version
-        if (window.XDomainRequest) {
+        var nativeXHR = new XMLHttpRequest();
+        if (window.XDomainRequest && ! "withCredentials" in nativeXHR) {
             Strophe.Request.prototype._newXHR = function() {
                 var xhr = new XDomainRequest();
                 xhr.readyState = 0;


### PR DESCRIPTION
IE10 supports both CORS and XDomainRequest. Since it supports both, this allows it to use CORS out-of-the-box and not rely on patching the native XHR object to support it as it's already there.
