### PR TITLE
Fix "[object Element]" error message

### DIFF
--- a/si-filetransfer/strophe.si-filetransfer.js
+++ b/si-filetransfer/strophe.si-filetransfer.js
@@ -102,7 +102,13 @@
 
     _fail: function (cb, stanza) {
       var err = 'timed out';
-      if (stanza) err = stanza;
+      if (stanza) {
+        var $error = $(stanza).find("iq > error");
+        var element = $error.children()[0]
+        if (element) {
+          err = element.tagName.toLowerCase();
+        }
+      }
       cb(new Error(err));
     },
 


### PR DESCRIPTION
_fail being calling with stanza error message instead of "[object Element]"
