### PR TITLE
Update strophe.disco.js

### DIFF
--- a/disco/strophe.disco.js
+++ b/disco/strophe.disco.js
@@ -127,7 +127,7 @@ Strophe.addConnectionPlugin('disco',
 
         var info = $iq({from:this._connection.jid,
                          to:jid, type:'get'}).c('query', attrs);
-        this._connection.sendIQ(info, success, error, timeout);
+        return this._connection.sendIQ(info, success, error, timeout);
     },
     /** Function: items
      * Items query


### PR DESCRIPTION
sendIQ returns the request id (which is subsequently used to pair the response handler). So it makes sense that info request returns id like others.